### PR TITLE
Replace implicit relative imports with explicit ones

### DIFF
--- a/scale_tests/agents_test.py
+++ b/scale_tests/agents_test.py
@@ -15,7 +15,7 @@
 
 from time import time
 
-from framework.constants import BLUEPRINT_TYPES
+from .framework.constants import BLUEPRINT_TYPES
 
 
 def test_agents(resource_creator, deployments_count, request, logger):

--- a/scale_tests/blueprints_test.py
+++ b/scale_tests/blueprints_test.py
@@ -15,7 +15,7 @@
 
 from time import time
 
-from framework import util
+from .framework import util
 
 
 def test_many_blueprints_uploads(manager, resource_creator, request, logger):

--- a/scale_tests/conftest.py
+++ b/scale_tests/conftest.py
@@ -4,9 +4,9 @@ import pytest
 from cosmo_tester.framework import util
 from cosmo_tester.framework.cluster import CloudifyCluster
 
-from framework.constants import BLUEPRINT_TYPES
-from framework.blueprint_example import BlueprintExample
-from framework.concurrent_resource_creator import ConcurrentResourceCreator
+from .framework.constants import BLUEPRINT_TYPES
+from .framework.blueprint_example import BlueprintExample
+from .framework.concurrent_resource_creator import ConcurrentResourceCreator
 
 pytest_plugins = "cosmo_tester.conftest"
 

--- a/scale_tests/deployments_test.py
+++ b/scale_tests/deployments_test.py
@@ -15,7 +15,7 @@
 
 from time import time
 
-from framework import util
+from .framework import util
 
 
 def test_many_deployments_creation(manager, resource_creator, deployments_count, logger):

--- a/scale_tests/framework/concurrent_resource_creator.py
+++ b/scale_tests/framework/concurrent_resource_creator.py
@@ -22,8 +22,8 @@ from retrying import retry
 
 from cloudify_rest_client import CloudifyClient
 
-from util import get_resource_list
-from constants import TERMINATED_STATE, PAGINATION_PARAMS
+from .util import get_resource_list
+from .constants import TERMINATED_STATE, PAGINATION_PARAMS
 
 
 class ConcurrentResourceCreator(object):

--- a/scale_tests/framework/util.py
+++ b/scale_tests/framework/util.py
@@ -16,7 +16,7 @@
 from time import time
 from retrying import retry
 
-from constants import TERMINATED_STATE, PAGINATION_PARAMS
+from .constants import TERMINATED_STATE, PAGINATION_PARAMS
 
 
 def check_disk_space(manager, logger):


### PR DESCRIPTION
Implicit relative imports are prone to breaking and bad style,
let's replace them with explicit imports instead.